### PR TITLE
Fix single line regex

### DIFF
--- a/tasks/phpmin.js
+++ b/tasks/phpmin.js
@@ -16,7 +16,7 @@ module.exports = function( grunt ) {
   grunt.registerMultiTask('phpmin', 'Minimize PHP files removing comments, tabs and newlines', function() {
 
     var trailingWhiteSpace = /[ \t]+$/gm,
-         singleLineComment = /'[^']*'|"[^"]*"|((?:#|\/\/).*$)/gm,
+         singleLineComment = /'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|((?:#|\/\/).*$)/gm,
           multilineComment = /^\s*\/\*\*?[^!][.\s\t\S\n\r]*?\*\//gm,
               tabsOrSpaces = /([ \t]{2,}|\t+)/g,
                    newLine = /\r?\n|\r/g;


### PR DESCRIPTION
Fixed an issue where strings with escaped quotations would cause the single line comment regular expression to end prematurely.